### PR TITLE
Reverse Swap (Breez -> LNBits), seed validation and enforce limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ SatsMobiBot
 old
 docs/
 
+# go test -c artifacts (avoid committing test binaries)
+*.test
+

--- a/botfather-setcommands.txt
+++ b/botfather-setcommands.txt
@@ -16,3 +16,4 @@ donate - Donate: /donate 1000
 faucet - Create a faucet: /faucet 2100 21 
 pos - Create POS
 advanced - Advanced help
+swap-ln - Swap from Safe (Breez) to Hot (LNbits): /swap-ln

--- a/docs/SEED_GENERATION_AND_SAFETY_REPORT.md
+++ b/docs/SEED_GENERATION_AND_SAFETY_REPORT.md
@@ -1,0 +1,223 @@
+# Seed generation & safety report (Breez “Safe” wallet)
+
+This document describes **how the Breez wallet seed phrase (mnemonic) is generated, stored, and revealed**, and gives a quick assessment of whether the current approach is “safe enough” and what the main risks are.
+
+## What is generated
+
+- **Mnemonic format**: BIP39 mnemonic phrase (currently **12 words**).
+- **Entropy**: **128 bits** (16 bytes) for 12 words.
+- **Passphrase**: empty string (no BIP39 passphrase is used).
+
+Where this is implemented:
+- `internal/breez/wallet.go` (`GenerateMnemonic()`)
+
+## How the mnemonic is generated
+
+The bot generates the mnemonic as follows:
+
+1. Allocate 16 bytes (128 bits) of entropy.
+2. Fill entropy using **`crypto/rand`** (cryptographically secure randomness from the OS).
+3. Convert entropy into a **BIP39 mnemonic** using `github.com/tyler-smith/go-bip39`.
+
+This is the right class of approach for mnemonic generation: **CSPRNG → BIP39 mnemonic**.
+
+Where this happens:
+- `internal/breez/wallet.go` (`GenerateMnemonic()` uses `rand.Read()` + `bip39.NewMnemonic()`).
+
+## When a mnemonic is created for a user
+
+Mnemonic creation happens during Telegram `/start` flow when:
+
+- Breez integration is enabled (`breez.enabled: true`), and
+- the user does not already have a stored Breez mnemonic.
+
+Flow:
+- `/start` → `initWallet()` → `initUserBreezWallet()`
+- If `user.BreezMnemonic == ""`, the bot generates a new mnemonic, encrypts it, and stores it in the DB.
+
+Where this happens:
+- `internal/telegram/start.go` (`initWallet`, `initUserBreezWallet`)
+
+## How the mnemonic is stored (at rest)
+
+The mnemonic is stored in the user record as `BreezMnemonic` (string field on `lnbits.User`), but **stored encrypted**.
+
+Encryption details:
+- **Algorithm**: AES-256-GCM (AEAD).
+- **Key**: `breez.encryption_key` from `config.yaml` (must be **64 hex chars** = 32 bytes).
+- **Nonce**: randomly generated per-encryption using `crypto/rand` (`io.ReadFull(rand.Reader, nonce)`).
+- **Stored format**: hex-encoded string of `nonce || ciphertext+tag` (GCM output).
+
+Where this happens:
+- `internal/breez/encryption.go` (`EncryptMnemonic`, `DecryptMnemonic`)
+- `internal/config.go` enforces the key presence/length when Breez is enabled.
+
+## How the mnemonic is used (in memory)
+
+On wallet init:
+- the bot decrypts the mnemonic (if present),
+- then initializes the Breez SDK client with the mnemonic.
+
+Where this happens:
+- `internal/telegram/start.go` (`initUserBreezWallet` → `initializeUserBreezClient(...)`)
+- `internal/telegram/bot.go` (reinitialization path: decrypt + init if client missing)
+
+## When the mnemonic is revealed to the user
+
+The user can retrieve the seed phrase via `/backup`:
+
+- Only allowed in **private chat**.
+- Bot decrypts mnemonic and sends it in a message.
+- Bot **deletes that message after 60 seconds**.
+- Bot logs that the user viewed the seed phrase (does not log the mnemonic itself).
+
+Where this happens:
+- `internal/telegram/backup.go` (`backupHandler`)
+
+Important note: Telegram messages are **not end-to-end encrypted** in standard cloud chats. Even if the bot deletes the message after 60 seconds, the seed phrase can be copied/forwarded/screenshotted.
+
+## Migration behavior (plaintext → encrypted)
+
+There is migration logic for older databases that might have stored the mnemonic **in plaintext**:
+
+- On decrypt failure, the code checks if the stored string “looks like” a mnemonic.
+- If yes, it encrypts it and overwrites `user.BreezMnemonic` with the encrypted value.
+
+Where this happens:
+- `internal/telegram/start.go` (`initUserBreezWallet`)
+- `internal/telegram/backup.go` (`backupHandler`)
+- `internal/telegram/bot.go` (client reinit path)
+
+### ⚠️ Weakness in mnemonic validation during migration
+
+`breez.ValidateMnemonic(...)` currently checks **only the word count** (12/15/18/21/24). It does **not** verify the BIP39 checksum (e.g., using `bip39.IsMnemonicValid`).
+
+Impact:
+- A random 12-word string could be treated as “valid plaintext mnemonic” during migration.
+- The system could then encrypt and persist garbage, and Breez initialization might fail later.
+
+This is more of a **robustness/safety** issue than a direct cryptographic weakness, but it’s worth fixing.
+
+Where this happens:
+- `internal/breez/wallet.go` (`ValidateMnemonic`)
+
+## Checksum validation (requested hardening)
+
+The code now validates the mnemonic using **BIP39 checksum** (not just word count):
+
+- `breez.ValidateMnemonic(...)` normalizes whitespace, checks valid word counts, then calls `bip39.IsMnemonicValid(...)`.
+- This validation is enforced:
+  - immediately after generating a mnemonic, and
+  - before initializing any Breez SDK client with a mnemonic, and
+  - before revealing the mnemonic via `/backup`, and
+  - before re-initializing a user Breez client from stored mnemonic.
+
+This ensures we never run a user wallet (or show a seed) if the mnemonic fails checksum validation.
+
+## Safety assessment (high-level)
+
+### What looks good
+
+- **Mnemonic generation** uses OS CSPRNG (`crypto/rand`) + BIP39. This is standard and safe.
+- **At-rest encryption** uses AES-256-GCM with random nonces, which is a strong modern choice.
+- Breez encryption key is validated to be **32 bytes** (64 hex chars) when Breez is enabled.
+- The bot does not print the mnemonic in logs (based on current code paths examined).
+
+### Main risks / assumptions
+
+- **Single server-wide encryption key** (`breez.encryption_key`):
+  - If the server is compromised or `config.yaml` leaks, an attacker can decrypt **all users’ Breez mnemonics** from the DB.
+  - There is no per-user key separation and no key rotation mechanism shown in code.
+
+- **Seed phrase delivery over Telegram** (`/backup`):
+  - Not E2EE in normal Telegram bot chats.
+  - Deleting after 60 seconds helps reduce accidental exposure but does not prevent copying/screenshotting or Telegram-side retention.
+
+- **12-word mnemonic**:
+  - 12 words (128-bit entropy) is commonly acceptable for Bitcoin wallets, but 24 words provides a larger security margin.
+  - The codebase already contains `GenerateMnemonic24()` but it is not used for user creation.
+
+- **Migration validation is too weak**:
+  - Word-count-only validation is insufficient to confirm a mnemonic is actually valid BIP39.
+
+## Bottom line
+
+- **Generation is correct and uses a safe randomness source**.
+- **Storage is encrypted and uses a good AEAD scheme**, but overall security strongly depends on keeping `breez.encryption_key` safe.
+- **The biggest practical exposure is `/backup`**, because it transmits the seed phrase via Telegram messages.
+
+## Adding a PIN / “second factor” for seed phrase access (research & difficulty)
+
+### First: what problem are we trying to solve?
+
+There are two common threat models:
+
+- **DB leak / backups leak** (attacker gets DB contents, but not runtime secrets or user interactions).
+- **Full server compromise** (attacker gets DB + `breez.encryption_key` and/or can modify the bot and intercept user inputs).
+
+A PIN/2FA mechanism can help a lot against **DB leak**, but **cannot fully protect against full server compromise** (because the server can always capture whatever the user types).
+
+### Option A (most practical): PIN-gated envelope encryption (recommended)
+
+Goal: even if the DB leaks, the attacker still can’t decrypt mnemonics without the user PIN.
+
+High-level design:
+
+- **Per user**, generate a random **data-encryption key (DEK)** to encrypt the mnemonic (AES-GCM).
+- Encrypt (“wrap”) the DEK using a key derived from:
+  - the server secret (`breez.encryption_key`, or better: a separate `seed_kek`), and
+  - a **user PIN** processed through a strong KDF (Argon2id / scrypt) with a per-user salt.
+- Store in DB:
+  - encrypted mnemonic (with DEK),
+  - wrapped DEK,
+  - KDF params + salt,
+  - optionally a PIN verifier hash for fast PIN checks.
+
+Runtime behavior:
+
+- Normal operations that require Breez (payments, swaps) need the mnemonic. You have to choose one UX model:
+  - **Unlocked session model (best UX)**: user enters PIN once; bot keeps the decrypted DEK/mnemonic **in memory** for some TTL (e.g., 30 minutes) and re-locks after inactivity/restart.
+  - **Always prompt model (most secure, worst UX)**: prompt PIN every time Breez is needed (likely unacceptable).
+
+Security notes:
+- Helps strongly against **DB-only compromise**.
+- Does **not** help if the attacker has control of the server process (they can capture PIN).
+
+Difficulty estimate in this codebase:
+- **Medium**. Requires new DB fields on `lnbits.User` (salt/params/wrapped key), a `/setpin` and `/pin` flow, and in-memory “unlock” cache.
+- Rough effort: ~1–3 days depending on UX and migration needs.
+
+### Option B: protect the server key using a real KMS/HSM (helps a different threat)
+
+If the main worry is that `breez.encryption_key` sitting in config is risky, you can:
+
+- move encryption keys out of `config.yaml`,
+- load them from environment variables, and ideally
+- use a managed KMS (AWS KMS / GCP KMS) or OS keychain/TPM-backed storage.
+
+This does **not** add a user second factor, but it materially improves:
+- accidental leaks (config file backups),
+- basic disk exfiltration,
+- operational key rotation.
+
+Difficulty: Low–Medium (mostly plumbing + deployment changes).
+
+### Option C: “2FA” via Telegram/OTP
+
+Classic TOTP (Google Authenticator) can be implemented, but note:
+
+- If the bot is compromised, it can still ask for/steal OTP codes.
+- This is still useful mainly against **DB leak** and some “offline attacker” scenarios.
+
+In practice, a **PIN (Option A)** is usually simpler than full TOTP UX in a Telegram bot.
+
+### Option D: don’t ever show the seed phrase again
+
+You could decide:
+- show seed only once at creation (and never again),
+- require the user to store it securely.
+
+But users will lose it, and support burden increases. Also, this does not address DB/server compromise; it’s just a UX/security trade.
+
+
+

--- a/internal/breez/wallet.go
+++ b/internal/breez/wallet.go
@@ -3,6 +3,7 @@ package breez
 import (
 	"crypto/rand"
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tyler-smith/go-bip39"
@@ -78,22 +79,22 @@ func ValidateMnemonic(mnemonic string) error {
 		return fmt.Errorf("mnemonic cannot be empty")
 	}
 
-	// Basic validation: check word count (12, 15, 18, 21, or 24 words)
-	words := len(splitMnemonic(mnemonic))
-	validCounts := []int{12, 15, 18, 21, 24}
-	valid := false
-	for _, count := range validCounts {
-		if words == count {
-			valid = true
-			break
-		}
-	}
+	// Normalize whitespace (BIP39 library expects words separated by single spaces)
+	normalized := strings.Join(strings.Fields(mnemonic), " ")
+	words := len(strings.Fields(normalized))
 
-	if !valid {
+	// Basic validation: check word count (12, 15, 18, 21, or 24 words)
+	validCounts := map[int]bool{12: true, 15: true, 18: true, 21: true, 24: true}
+	if !validCounts[words] {
 		return fmt.Errorf("invalid mnemonic: expected 12, 15, 18, 21, or 24 words, got %d", words)
 	}
 
-	log.Debug("[Breez] Mnemonic validation passed")
+	// Strong validation: verify checksum & wordlist membership
+	if !bip39.IsMnemonicValid(normalized) {
+		return fmt.Errorf("invalid mnemonic: checksum or wordlist validation failed")
+	}
+
+	log.Debug("[Breez] Mnemonic validation passed (checksum OK)")
 	return nil
 }
 
@@ -135,6 +136,11 @@ func GenerateMnemonic() (string, error) {
 	mnemonic, err := bip39.NewMnemonic(entropy)
 	if err != nil {
 		return "", fmt.Errorf("failed to create mnemonic from entropy: %w", err)
+	}
+
+	// Sanity-check: ensure mnemonic passes checksum validation
+	if err := ValidateMnemonic(mnemonic); err != nil {
+		return "", fmt.Errorf("generated mnemonic failed validation: %w", err)
 	}
 
 	log.Debug("[Breez] Generated new 12-word BIP39 mnemonic")

--- a/internal/config.go
+++ b/internal/config.go
@@ -166,20 +166,18 @@ func checkLnbitsConfiguration() {
 }
 
 func checkLimitsConfiguration() {
-	// Set defaults if not configured
+	// Validate required configuration
 	if Configuration.Limits.LNbitsMaxBalance == 0 {
-		Configuration.Limits.LNbitsMaxBalance = 50000 // 50k sats default
+		panic(fmt.Errorf("please configure limits.lnbits_max_balance in config.yaml"))
 	}
 	if Configuration.Limits.AutoSwapThreshold == 0 {
-		Configuration.Limits.AutoSwapThreshold = 60000 // 60k sats default
+		panic(fmt.Errorf("please configure limits.auto_swap_threshold in config.yaml"))
 	}
 
 	// Validate that auto-swap threshold is greater than max balance
 	if Configuration.Limits.AutoSwapThreshold <= Configuration.Limits.LNbitsMaxBalance {
-		log.Warnf("[Config] auto_swap_threshold (%d) should be greater than lnbits_max_balance (%d), using default values",
-			Configuration.Limits.AutoSwapThreshold, Configuration.Limits.LNbitsMaxBalance)
-		Configuration.Limits.LNbitsMaxBalance = 50000
-		Configuration.Limits.AutoSwapThreshold = 60000
+		panic(fmt.Errorf("limits.auto_swap_threshold (%d) must be greater than limits.lnbits_max_balance (%d)",
+			Configuration.Limits.AutoSwapThreshold, Configuration.Limits.LNbitsMaxBalance))
 	}
 
 	log.Infof("[Config] Limits: LNbits max balance=%d sats, Auto-swap threshold=%d sats",

--- a/internal/lnbits/types.go
+++ b/internal/lnbits/types.go
@@ -78,6 +78,7 @@ const (
 	UserEnterDallePrompt
 	UserStateRefundAwaitingAddress
 	UserStateSwapEnterAmount
+	UserStateSwapLNEnterAmount
 )
 
 type UserStateKey int

--- a/internal/telegram/backup.go
+++ b/internal/telegram/backup.go
@@ -60,6 +60,13 @@ func (bot *TipBot) backupHandler(ctx intercept.Context) (intercept.Context, erro
 		}
 	}
 
+	// Never reveal an invalid mnemonic (checksum)
+	if valErr := breez.ValidateMnemonic(mnemonic); valErr != nil {
+		log.Errorf("[/backup] Refusing to show invalid mnemonic to user %s: %s", GetUserStr(user.Telegram), valErr)
+		bot.trySendMessage(m.Sender, Translate(ctx, "backupNoMnemonicMessage"))
+		return ctx, fmt.Errorf("invalid mnemonic: %w", valErr)
+	}
+
 	// Send warning message first
 	bot.trySendMessage(m.Sender, Translate(ctx, "backupWarningMessage"))
 	time.Sleep(2 * time.Second)

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -151,6 +151,12 @@ func (bot *TipBot) GetUserBreezClient(user *lnbits.User) *breez.Client {
 				}
 			}
 
+			// Final guardrail: don't initialize Breez with an invalid mnemonic (checksum)
+			if valErr := breez.ValidateMnemonic(mnemonic); valErr != nil {
+				log.Errorf("[GetUserBreezClient] Refusing to initialize Breez with invalid mnemonic for user %d: %s", user.Telegram.ID, valErr)
+				return nil
+			}
+
 			client, err := bot.initializeUserBreezClient(user.Telegram.ID, mnemonic)
 			if err != nil {
 				log.Errorf("[GetUserBreezClient] Failed to reinitialize: %s", err)

--- a/internal/telegram/handler.go
+++ b/internal/telegram/handler.go
@@ -293,6 +293,22 @@ func (bot TipBot) getHandler() []InterceptionWrapper {
 				},
 			},
 		},
+		{
+			Endpoints: []interface{}{"/swap-ln"},
+			Handler:   bot.swapLNHandler,
+			Interceptor: &Interceptor{
+				Before: []intercept.Func{
+					bot.requirePrivateChatInterceptor,
+					bot.localizerInterceptor,
+					bot.logMessageInterceptor,
+					bot.requireUserInterceptor,
+					bot.lockInterceptor,
+				},
+				OnDefer: []intercept.Func{
+					bot.unlockInterceptor,
+				},
+			},
+		},
 
 		{
 			Endpoints: []interface{}{"/invoice", &btnInvoiceMainMenu},

--- a/internal/telegram/invoice.go
+++ b/internal/telegram/invoice.go
@@ -546,12 +546,6 @@ func (bot *TipBot) checkAndPerformAutoSwap(user *lnbits.User) {
 	// Get thresholds from config
 	S := internal.Configuration.Limits.LNbitsMaxBalance
 	S2 := internal.Configuration.Limits.AutoSwapThreshold
-	if S == 0 {
-		S = 50000
-	}
-	if S2 == 0 {
-		S2 = 60000
-	}
 
 	// Check if balance exceeds auto-swap threshold
 	if lnbitsBalance <= S2 {

--- a/internal/telegram/start.go
+++ b/internal/telegram/start.go
@@ -205,6 +205,12 @@ func (bot *TipBot) initUserBreezWallet(user *lnbits.User) error {
 			return fmt.Errorf("failed to generate mnemonic: %w", err)
 		}
 
+		// Validate generated mnemonic (checksum)
+		if valErr := breez.ValidateMnemonic(mnemonic); valErr != nil {
+			bot.tryDeleteMessage(creationMsg)
+			return fmt.Errorf("generated mnemonic failed validation: %w", valErr)
+		}
+
 		// Encrypt the mnemonic
 		encryptedMnemonic, err := breez.EncryptMnemonic(mnemonic, internal.Configuration.Breez.EncryptionKey)
 		if err != nil {
@@ -226,6 +232,12 @@ func (bot *TipBot) initUserBreezWallet(user *lnbits.User) error {
 		time.AfterFunc(3*time.Second, func() {
 			bot.tryDeleteMessage(creationMsg)
 		})
+	}
+
+	// Final guardrail: never initialize Breez with an invalid mnemonic
+	if valErr := breez.ValidateMnemonic(mnemonic); valErr != nil {
+		log.Errorf("[Breez] Refusing to initialize Breez client with invalid mnemonic for user %s: %s", GetUserStr(user.Telegram), valErr)
+		return fmt.Errorf("invalid mnemonic: %w", valErr)
 	}
 
 	// Initialize Breez client with decrypted mnemonic

--- a/internal/telegram/state.go
+++ b/internal/telegram/state.go
@@ -23,5 +23,6 @@ func initializeStateCallbackMessage(bot *TipBot) {
 		lnbits.UserEnterDallePrompt:           bot.confirmGenerateImages,
 		lnbits.UserStateRefundAwaitingAddress: bot.handleRefundAddressInput,
 		lnbits.UserStateSwapEnterAmount:       bot.enterSwapAmountHandler,
+		lnbits.UserStateSwapLNEnterAmount:     bot.enterSwapLNAmountHandler,
 	}
 }

--- a/internal/telegram/swap.go
+++ b/internal/telegram/swap.go
@@ -293,6 +293,208 @@ func (bot *TipBot) swapToLNbitsHandler(ctx intercept.Context) (intercept.Context
 	return ctx, nil
 }
 
+// swapLNHandler handles the /swap-ln command - asks user for amount (Breez/Safe -> LNbits/Hot)
+func (bot *TipBot) swapLNHandler(ctx intercept.Context) (intercept.Context, error) {
+	// check and print all commands
+	bot.anyTextHandler(ctx)
+
+	user := LoadUser(ctx)
+	if user.Wallet == nil {
+		return ctx, errors.Create(errors.UserNoWalletError)
+	}
+
+	userStr := GetUserStr(ctx.Sender())
+
+	// Check if Breez is initialized
+	userBreez := bot.GetUserBreezClient(user)
+	if userBreez == nil || !userBreez.IsInitialized() {
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "swapBreezNotInitialized"))
+		log.Warnf("[/swap-ln] %s tried to swap-ln but Breez not initialized", userStr)
+		return ctx, errors.Create(errors.UserNoWalletError)
+	}
+
+	// Get Breez balance
+	breezBalance, err := bot.GetBreezBalance(user)
+	if err != nil {
+		log.Errorf("[/swap-ln] Error fetching %s's Breez balance: %s", userStr, err)
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "errorTryLaterMessage"))
+		return ctx, err
+	}
+
+	// Get LNbits balance
+	lnbitsBalance, err := bot.GetLNbitsBalance(user)
+	if err != nil {
+		log.Errorf("[/swap-ln] Error fetching %s's LNbits balance: %s", userStr, err)
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "errorTryLaterMessage"))
+		return ctx, err
+	}
+
+	// Get S (LNbits max balance) from config
+	S := internal.Configuration.Limits.LNbitsMaxBalance
+	if S == 0 {
+		S = 50000
+	}
+
+	// LNbits capacity remaining
+	capacity := S - lnbitsBalance
+	if capacity <= 0 {
+		bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "swapToLNbitsFull"), lnbitsBalance, S))
+		log.Warnf("[/swap-ln] %s's LNbits already at capacity: %d >= %d", userStr, lnbitsBalance, S)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	// Max by Breez balance with a conservative fee model (1% + 100 sats)
+	// Require: amount + (amount*1% + 100) <= breezBalance  => amount <= (breezBalance - 100) / 1.01
+	maxByBreez := int64(0)
+	if breezBalance > 100 {
+		maxByBreez = int64(float64(breezBalance-100) / 1.01)
+	}
+
+	maxAllowed := capacity
+	if maxByBreez < maxAllowed {
+		maxAllowed = maxByBreez
+	}
+	if maxAllowed > breezBalance {
+		maxAllowed = breezBalance
+	}
+
+	if maxAllowed < MinimumSwapAmount {
+		// If Breez has funds but fees would eat everything, use the dedicated message; otherwise generic minimum
+		estimatedFees := int64(float64(maxAllowed)*0.01) + 100
+		if estimatedFees < 100 {
+			estimatedFees = 100
+		}
+		if breezBalance >= MinimumSwapAmount && capacity >= MinimumSwapAmount {
+			bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "swapToLNbitsInsufficientAfterFees"), breezBalance, estimatedFees))
+		} else {
+			bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "swapToLNbitsMinimum"), MinimumSwapAmount, breezBalance))
+		}
+		log.Warnf("[/swap-ln] %s max allowed too low: max=%d, breez=%d, capacity=%d", userStr, maxAllowed, breezBalance, capacity)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	promptMessage := fmt.Sprintf(Translate(ctx, "swapLNAmountPrompt"), MinimumSwapAmount, maxAllowed, breezBalance, lnbitsBalance, S)
+	bot.trySendMessage(ctx.Sender(), promptMessage)
+
+	// Set user state to wait for amount input
+	SetUserState(user, bot, lnbits.UserStateSwapLNEnterAmount, "")
+	log.Infof("[/swap-ln] %s initiated swap-ln, waiting for amount (maxAllowed=%d)", userStr, maxAllowed)
+
+	return ctx, nil
+}
+
+// enterSwapLNAmountHandler processes user's swap-ln amount input (Breez/Safe -> LNbits/Hot)
+func (bot *TipBot) enterSwapLNAmountHandler(ctx intercept.Context) (intercept.Context, error) {
+	user := LoadUser(ctx)
+	if user.Wallet == nil {
+		return ctx, errors.Create(errors.UserNoWalletError)
+	}
+
+	userStr := GetUserStr(ctx.Sender())
+
+	// Parse amount from message
+	amountStr := strings.TrimSpace(ctx.Message().Text)
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	if err != nil || amount <= 0 {
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "invalidAmountMessage"))
+		log.Warnf("[enterSwapLNAmount] %s entered invalid amount: %s", userStr, amountStr)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	// Check minimum amount
+	if amount < MinimumSwapAmount {
+		bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "swapMinimumAmount"), MinimumSwapAmount))
+		log.Warnf("[enterSwapLNAmount] %s entered amount below minimum: %d sats", userStr, amount)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	// Check Breez initialized + balances + LNbits capacity
+	userBreez := bot.GetUserBreezClient(user)
+	if userBreez == nil || !userBreez.IsInitialized() {
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "swapBreezNotInitialized"))
+		return ctx, errors.Create(errors.UserNoWalletError)
+	}
+
+	breezBalance, err := bot.GetBreezBalance(user)
+	if err != nil {
+		log.Errorf("[enterSwapLNAmount] Error fetching %s's Breez balance: %s", userStr, err)
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "errorTryLaterMessage"))
+		return ctx, err
+	}
+
+	lnbitsBalance, err := bot.GetLNbitsBalance(user)
+	if err != nil {
+		log.Errorf("[enterSwapLNAmount] Error fetching %s's LNbits balance: %s", userStr, err)
+		bot.trySendMessage(ctx.Sender(), Translate(ctx, "errorTryLaterMessage"))
+		return ctx, err
+	}
+
+	S := internal.Configuration.Limits.LNbitsMaxBalance
+	if S == 0 {
+		S = 50000
+	}
+
+	capacity := S - lnbitsBalance
+	if capacity <= 0 {
+		bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "swapToLNbitsFull"), lnbitsBalance, S))
+		log.Warnf("[enterSwapLNAmount] %s's LNbits already at capacity: %d >= %d", userStr, lnbitsBalance, S)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	if amount > capacity {
+		bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "enterAmountRangeMessage"), MinimumSwapAmount, capacity))
+		log.Warnf("[enterSwapLNAmount] %s entered amount above capacity: amount=%d capacity=%d", userStr, amount, capacity)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	// Conservative fee check (real fee is enforced at execution time)
+	estimatedFees := int64(float64(amount)*0.01) + 100
+	if estimatedFees < 100 {
+		estimatedFees = 100
+	}
+	if amount+estimatedFees > breezBalance {
+		bot.trySendMessage(ctx.Sender(), fmt.Sprintf(Translate(ctx, "swapToLNbitsInsufficientAfterFees"), breezBalance, estimatedFees))
+		log.Warnf("[enterSwapLNAmount] %s insufficient Breez balance after fees: breez=%d amount=%d estFees=%d", userStr, breezBalance, amount, estimatedFees)
+		return ctx, errors.Create(errors.InvalidAmountError)
+	}
+
+	// Reset user state
+	ResetUserState(user, bot)
+
+	// Show confirmation with fee estimate (same format used by /swaptolnbits)
+	newLNbitsBalance := lnbitsBalance + amount
+	confirmText := fmt.Sprintf(Translate(ctx, "swapToLNbitsConfirmation"),
+		amount, breezBalance, lnbitsBalance, newLNbitsBalance, estimatedFees)
+
+	// Create swap confirmation data
+	id := fmt.Sprintf("swapln:%d-%d-%s", ctx.Sender().ID, amount, RandStringRunes(5))
+
+	confirmButton := swapConfirmationMenu.Data(Translate(ctx, "swapButtonConfirm"), "confirm_swap_to_lnbits", id)
+	cancelButton := swapConfirmationMenu.Data(Translate(ctx, "swapButtonCancel"), "cancel_swap", id)
+
+	swapConfirmationMenu.Inline(
+		swapConfirmationMenu.Row(
+			confirmButton,
+			cancelButton),
+	)
+
+	swapMessage := bot.trySendMessageEditable(ctx.Chat(), confirmText, swapConfirmationMenu)
+
+	swapData := &SwapData{
+		Base:            storage.New(storage.ID(id)),
+		From:            user,
+		Amount:          amount,
+		Message:         confirmText,
+		LanguageCode:    ctx.Value("publicLanguageCode").(string),
+		TelegramMessage: swapMessage,
+	}
+
+	runtime.IgnoreError(swapData.Set(swapData, bot.Bunt))
+	log.Infof("[enterSwapLNAmount] User: %s, amount: %d sat (LNbits %d->%d, estFees=%d)", userStr, amount, lnbitsBalance, newLNbitsBalance, estimatedFees)
+
+	return ctx, nil
+}
+
 // enterSwapAmountHandler processes user's swap amount input
 func (bot *TipBot) enterSwapAmountHandler(ctx intercept.Context) (intercept.Context, error) {
 	user := LoadUser(ctx)
@@ -736,10 +938,21 @@ func (bot *TipBot) executeReverseSwap(user *lnbits.User, amount int64, ctx inter
 		return fmt.Errorf("amount below minimum: %d < %d", amount, MinimumSwapAmount)
 	}
 
-	// Add 1% buffer for fees
-	requiredBalance := int64(float64(amount) * 1.01)
-	if requiredBalance > breezBalance {
-		return fmt.Errorf("insufficient Breez balance (including fees): %d < %d", breezBalance, requiredBalance)
+	// Enforce LNbits max balance (S) at execution time too
+	lnbitsBalance, err := bot.GetLNbitsBalance(user)
+	if err != nil {
+		return fmt.Errorf("failed to get LNbits balance: %w", err)
+	}
+	S := internal.Configuration.Limits.LNbitsMaxBalance
+	if S == 0 {
+		S = 50000
+	}
+	capacity := S - lnbitsBalance
+	if capacity <= 0 {
+		return fmt.Errorf("lnbits wallet full: balance=%d >= max=%d", lnbitsBalance, S)
+	}
+	if amount > capacity {
+		return fmt.Errorf("amount exceeds lnbits capacity: amount=%d > capacity=%d (balance=%d max=%d)", amount, capacity, lnbitsBalance, S)
 	}
 
 	// 4. Create LNbits invoice
@@ -757,7 +970,16 @@ func (bot *TipBot) executeReverseSwap(user *lnbits.User, amount int64, ctx inter
 
 	log.Infof("[executeReverseSwap] Created LNbits invoice for %s: %s", userStr, invoice.PaymentRequest)
 
-	// 5. Pay invoice from Breez
+	// 5. Enforce Breez balance including *real* fee estimate
+	feeSats, feeErr := userBreez.EstimatePaymentFee(invoice.PaymentRequest)
+	if feeErr != nil {
+		return fmt.Errorf("failed to estimate Breez fee: %w", feeErr)
+	}
+	if amount+feeSats > breezBalance {
+		return fmt.Errorf("insufficient Breez balance (amount+fee): balance=%d < need=%d (amount=%d fee=%d)", breezBalance, amount+feeSats, amount, feeSats)
+	}
+
+	// 6. Pay invoice from Breez
 	_, err = userBreez.PayInvoice(invoice.PaymentRequest)
 	if err != nil {
 		return fmt.Errorf("failed to pay invoice from Breez: %w", err)
@@ -765,14 +987,14 @@ func (bot *TipBot) executeReverseSwap(user *lnbits.User, amount int64, ctx inter
 
 	log.Infof("[executeReverseSwap] Paid invoice from Breez for %s", userStr)
 
-	// 6. Sync Breez balance
+	// 7. Sync Breez balance
 	err = userBreez.RefreshBalance()
 	if err != nil {
 		log.Warnf("[executeReverseSwap] Failed to sync Breez balance for %s: %s", userStr, err)
 		// Don't return error, swap was successful
 	}
 
-	// 7. Clear balance cache
+	// 8. Clear balance cache
 	cacheKey := fmt.Sprintf("%s_balance", user.Name)
 	bot.Cache.Delete(cacheKey)
 

--- a/internal/telegram/swap.go
+++ b/internal/telegram/swap.go
@@ -214,9 +214,6 @@ func (bot *TipBot) swapToLNbitsHandler(ctx intercept.Context) (intercept.Context
 
 	// Get S (LNbits max balance) from config
 	S := internal.Configuration.Limits.LNbitsMaxBalance
-	if S == 0 {
-		S = 50000
-	}
 
 	// Calculate maximum amount we can swap: S - B
 	maxSwapAmount := S - lnbitsBalance
@@ -331,9 +328,6 @@ func (bot *TipBot) swapLNHandler(ctx intercept.Context) (intercept.Context, erro
 
 	// Get S (LNbits max balance) from config
 	S := internal.Configuration.Limits.LNbitsMaxBalance
-	if S == 0 {
-		S = 50000
-	}
 
 	// LNbits capacity remaining
 	capacity := S - lnbitsBalance
@@ -430,9 +424,6 @@ func (bot *TipBot) enterSwapLNAmountHandler(ctx intercept.Context) (intercept.Co
 	}
 
 	S := internal.Configuration.Limits.LNbitsMaxBalance
-	if S == 0 {
-		S = 50000
-	}
 
 	capacity := S - lnbitsBalance
 	if capacity <= 0 {
@@ -944,9 +935,6 @@ func (bot *TipBot) executeReverseSwap(user *lnbits.User, amount int64, ctx inter
 		return fmt.Errorf("failed to get LNbits balance: %w", err)
 	}
 	S := internal.Configuration.Limits.LNbitsMaxBalance
-	if S == 0 {
-		S = 50000
-	}
 	capacity := S - lnbitsBalance
 	if capacity <= 0 {
 		return fmt.Errorf("lnbits wallet full: balance=%d >= max=%d", lnbitsBalance, S)

--- a/removed/buy.go
+++ b/removed/buy.go
@@ -1,3 +1,6 @@
+//go:build ignore
+// +build ignore
+
 package telegram
 
 import (

--- a/removed/voucherbot.go
+++ b/removed/voucherbot.go
@@ -1,3 +1,6 @@
+//go:build ignore
+// +build ignore
+
 package telegram
 
 import (

--- a/translations/en.toml
+++ b/translations/en.toml
@@ -130,6 +130,8 @@ advancedMessage = """%s
 */backup*: Backup your Safe wallet Seedphrase: `/backup`
 */buybtc*: Buy Bitcoin with Moonpay: `/buybtc`
 */swap*: Swap funds from Hot balance to Safe: `/swap <amount>` or `/swap-all`
+*/swaptolnbits*: Fill Hot from Safe up to the max (S): `/swaptolnbits`
+*/swap-ln*: Swap funds from Safe to Hot: `/swap-ln` then enter an amount
 """
 
 # GENERIC
@@ -686,3 +688,13 @@ swapToLNbitsSuccess = """✅ *Swap to Hot Balance Complete!*
 %d sats have been transferred from Safe Balance to your Hot Balance.
 
 Use /balance to check your updated balances. Please note that balances may take 2 minutes to update."""
+
+swapLNAmountPrompt = """💱 *Enter Swap Amount*
+
+Please enter the amount you want to swap from Safe to Hot Balance.
+
+Minimum: %d Sats
+Maximum: %d Sats
+
+Your Safe balance: %d Sats
+Your Hot balance: %d Sats (max %d)"""

--- a/translations/es.toml
+++ b/translations/es.toml
@@ -129,6 +129,8 @@ advancedMessage = """%s
 */backup*: Respaldar la frase semilla de tu billetera Breez: `/backup`
 */buybtc*: Comprar Bitcoin con Moonpay: `/buybtc`
 */swap*: Intercambiar fondos de LNbits a Breez: `/swap <cantidad>` o `/swap-all`
+*/swaptolnbits*: Llenar Hot desde Safe hasta el máximo (S): `/swaptolnbits`
+*/swap-ln*: Intercambiar fondos de Safe a Hot: `/swap-ln` e ingresa una cantidad
 """
 
 # GENERIC
@@ -616,3 +618,52 @@ swapButtonConfirm = """✅ Confirmar Intercambio"""
 swapButtonCancel = """🚫 Cancelar"""
 swapCancelled = """Intercambio cancelado."""
 processingMessage = """⏳ Procesando..."""
+
+# SWAP TO LNBITS (Breez -> LNbits)
+swapToLNbitsMinimum = """⚠️ *Saldo Insuficiente*
+
+Tu saldo Safe: %d sats
+Monto mínimo para intercambio: %d sats
+
+Por favor, recibe más fondos antes de intercambiar."""
+
+swapToLNbitsFull = """⚠️ *Billetera Hot Llena*
+
+Tu saldo Hot: %d sats
+Capacidad máxima: %d sats
+
+Tu billetera Hot ya está en su capacidad máxima. Debes mantener fondos en tu billetera Safe auto-custodial."""
+
+swapToLNbitsInsufficientAfterFees = """⚠️ *Saldo Insuficiente Después de Comisiones*
+
+Tu saldo Safe: %d sats
+Comisiones estimadas: ~%d sats
+
+El monto restante después de comisiones sería demasiado pequeño para intercambiar. Por favor, recibe más fondos primero."""
+
+swapToLNbitsConfirmation = """💱 *Confirmar Intercambio a Hot*
+
+¿Intercambiar *%d sats* de Safe a Hot?
+
+Saldo Safe actual: %d sats
+Saldo Hot actual: %d sats
+Saldo Hot después: %d sats
+Comisiones estimadas: ~%d sats
+
+Esto llenará tu billetera custodial hasta su límite."""
+
+swapToLNbitsSuccess = """✅ *¡Intercambio a Hot Completado!*
+
+%d sats han sido transferidos desde Safe a tu saldo Hot.
+
+Usa /balance para verificar tus saldos actualizados. Ten en cuenta que los saldos pueden tardar hasta 2 minutos en actualizarse."""
+
+swapLNAmountPrompt = """💱 *Ingresar Cantidad de Intercambio*
+
+Por favor, ingresa la cantidad que deseas intercambiar de Safe a Hot.
+
+Mínimo: %d sats
+Máximo: %d sats
+
+Tu saldo Safe: %d sats
+Tu saldo Hot: %d sats (máx %d)"""

--- a/translations/fr.toml
+++ b/translations/fr.toml
@@ -124,6 +124,8 @@ advancedMessage = """%s
 */backup*: Sauvegarder votre phrase de récupération Breez: `/backup`
 */buybtc*: Acheter Bitcoin avec Moonpay: `/buybtc`
 */swap*: Échanger des fonds de LNbits à Breez: `/swap <montant>` ou `/swap-all`
+*/swaptolnbits*: Remplir Hot depuis Safe jusqu'au maximum (S) : `/swaptolnbits`
+*/swap-ln*: Échanger des fonds de Safe à Hot : `/swap-ln` puis entrez un montant
 """
 
 # GENERIC
@@ -545,3 +547,52 @@ swapButtonConfirm = """✅ Confirmer l'Échange"""
 swapButtonCancel = """🚫 Annuler"""
 swapCancelled = """Échange annulé."""
 processingMessage = """⏳ Traitement en cours..."""
+
+# SWAP TO LNBITS (Breez -> LNbits)
+swapToLNbitsMinimum = """⚠️ *Solde insuffisant*
+
+Votre solde Safe : %d sats
+Montant minimum : %d sats
+
+Veuillez recevoir plus de fonds avant de swapper."""
+
+swapToLNbitsFull = """⚠️ *Wallet Hot plein*
+
+Votre solde Hot : %d sats
+Capacité maximale : %d sats
+
+Votre wallet Hot est déjà à sa capacité maximale. Gardez vos fonds dans votre wallet Safe (self-custodial)."""
+
+swapToLNbitsInsufficientAfterFees = """⚠️ *Solde insuffisant après frais*
+
+Votre solde Safe : %d sats
+Frais estimés : ~%d sats
+
+Le montant restant après frais serait trop faible pour swapper. Veuillez recevoir plus de fonds."""
+
+swapToLNbitsConfirmation = """💱 *Confirmer le swap vers Hot*
+
+Swapper *%d sats* de Safe vers Hot ?
+
+Solde Safe actuel : %d sats
+Solde Hot actuel : %d sats
+Solde Hot après swap : %d sats
+Frais estimés : ~%d sats
+
+Cela remplira votre wallet custodial jusqu'à sa limite."""
+
+swapToLNbitsSuccess = """✅ *Swap vers Hot terminé !*
+
+%d sats ont été transférés du solde Safe vers votre solde Hot.
+
+Utilisez /balance pour vérifier vos soldes. Note : la mise à jour peut prendre jusqu'à 2 minutes."""
+
+swapLNAmountPrompt = """💱 *Entrer le montant du swap*
+
+Veuillez entrer le montant que vous souhaitez swapper de Safe vers Hot.
+
+Minimum : %d sats
+Maximum : %d sats
+
+Votre solde Safe : %d sats
+Votre solde Hot : %d sats (max %d)"""

--- a/translations/it.toml
+++ b/translations/it.toml
@@ -123,6 +123,8 @@ advancedMessage = """%s
 */backup*: Backup della frase di recupero del portafoglio Breez: `/backup`
 */buybtc*: Acquista Bitcoin con Moonpay: `/buybtc`
 */swap*: Scambia fondi da LNbits a Breez: `/swap <importo>` o `/swap-all`
+*/swaptolnbits*: Riempi Hot da Safe fino al massimo (S): `/swaptolnbits`
+*/swap-ln*: Scambia fondi da Safe a Hot: `/swap-ln` e poi inserisci un importo
 """
 
 # GENERIC
@@ -541,3 +543,52 @@ swapButtonConfirm = """✅ Conferma Scambio"""
 swapButtonCancel = """🚫 Annulla"""
 swapCancelled = """Scambio annullato."""
 processingMessage = """⏳ Elaborazione..."""
+
+# SWAP TO LNBITS (Breez -> LNbits)
+swapToLNbitsMinimum = """⚠️ *Saldo insufficiente*
+
+Il tuo saldo Safe: %d sats
+Importo minimo: %d sats
+
+Ricevi più fondi prima di effettuare lo swap."""
+
+swapToLNbitsFull = """⚠️ *Wallet Hot pieno*
+
+Il tuo saldo Hot: %d sats
+Capacità massima: %d sats
+
+Il tuo wallet Hot è già alla capacità massima. Mantieni i fondi nel wallet Safe (self-custodial)."""
+
+swapToLNbitsInsufficientAfterFees = """⚠️ *Saldo insufficiente dopo commissioni*
+
+Il tuo saldo Safe: %d sats
+Commissioni stimate: ~%d sats
+
+L'importo rimanente dopo le commissioni sarebbe troppo basso per effettuare lo swap. Ricevi prima più fondi."""
+
+swapToLNbitsConfirmation = """💱 *Conferma swap verso Hot*
+
+Scambiare *%d sats* da Safe a Hot?
+
+Saldo Safe attuale: %d sats
+Saldo Hot attuale: %d sats
+Saldo Hot dopo swap: %d sats
+Commissioni stimate: ~%d sats
+
+Questo riempirà il wallet custodial fino al suo limite."""
+
+swapToLNbitsSuccess = """✅ *Swap verso Hot completato!*
+
+%d sats sono stati trasferiti dal saldo Safe al tuo saldo Hot.
+
+Usa /balance per verificare i saldi aggiornati. Nota: l'aggiornamento può richiedere fino a 2 minuti."""
+
+swapLNAmountPrompt = """💱 *Inserisci importo swap*
+
+Inserisci l'importo che vuoi scambiare da Safe a Hot.
+
+Minimo: %d sats
+Massimo: %d sats
+
+Il tuo saldo Safe: %d sats
+Il tuo saldo Hot: %d sats (max %d)"""


### PR DESCRIPTION
This PR adds Breez ↔ LNbits swap support (reverse swap) in both directions by introducing /swap-ln (Breez/Safe → LNbits/Hot) with the same limit enforcement patterns and confirmations as existing swaps.

It also hardens Breez seed handling by enforcing BIP39 checksum validation after creation and every time the mnemonic is used (init/reinit/backup), and includes a short seed/security report.

Finally, it makes limits strictly configurable: `limits.lnbits_max_balance` and `limits.auto_swap_threshold` are now required in `config.yaml` (no hardcoded defaults).